### PR TITLE
fix: google_service_account to point to a project

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,4 +67,5 @@ resource "google_service_account_key" "lacework" {
 data "google_service_account" "selected" {
   count      = var.create ? 0 : 1
   account_id = var.service_account_name
+  project    = local.project_id
 }


### PR DESCRIPTION
From [Google's documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account#project):
>`project` - (Optional) The ID of the project that the service account is present in. Defaults to the provider project configuration.

We must use the variable `local.project_id` since users might be
configuring separate projects as well as organization level integration.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>
