### PR TITLE
fix: prevent creating service account

### DIFF
--- a/examples/custom-organization-level-service-account/README.md
+++ b/examples/custom-organization-level-service-account/README.md
@@ -1,0 +1,28 @@
+# Create Service Account With Custom Settings
+
+This example shows how to create a service account to provide Lacework
+read-only access to a Google Cloud Organization and customizing the account
+with a few inputs.
+
+## Example
+
+Code inside a `main.tf` file:
+
+```hcl
+provider "google" {}
+
+module "lacework_svc_account" {
+  source               = "lacework/audit-log/gcp"
+  version              = "~> 0.1.0"
+  org_integration      = true
+  organization_id      = "my-organization-id"
+  project_id           = "my-project"
+  service_account_name = "lacework-custom-svc-account"
+}
+```
+
+Run Terraform:
+```
+$ terraform init
+$ GOOGLE_CREDENTIALS=account.json terraform apply
+```

--- a/examples/default-project-level-service-account/README.md
+++ b/examples/default-project-level-service-account/README.md
@@ -1,0 +1,23 @@
+# Create Service Account With Default Settings
+
+This example shows how to create a service account to provide Lacework
+read-only access to a Google Cloud Project.
+
+## Example
+
+Code inside a `main.tf` file:
+
+```hcl
+provider "google" {}
+
+module "lacework_svc_account" {
+  source  = "lacework/audit-log/gcp"
+  version = "~> 0.1.0"
+}
+```
+
+Run Terraform:
+```
+$ terraform init
+$ GOOGLE_CREDENTIALS=account.json GOOGLE_PROJECT=my-project terraform apply
+```

--- a/examples/prevent-service-account-creation/README.md
+++ b/examples/prevent-service-account-creation/README.md
@@ -1,0 +1,24 @@
+# Prevent Creating Service Account
+
+This example shows how another Terraform module could pass the
+`create` input to prevent creating a service account. (useful
+when a user wants to use an existing service account)
+
+## Example
+
+Code inside a `main.tf` file:
+```hcl
+provider "google" {}
+
+module "lacework_svc_account" {
+  source  = "lacework/service-account/gcp"
+  version = "~> 0.1.0"
+  create  = false
+}
+```
+
+Run Terraform:
+```
+$ terraform init
+$ GOOGLE_CREDENTIALS=account.json GOOGLE_PROJECT=my-project terraform apply
+```

--- a/examples/prevent-service-account-creation/main.tf
+++ b/examples/prevent-service-account-creation/main.tf
@@ -1,0 +1,13 @@
+// This example shows how another Terraform module could pass the
+// 'create' input to prevent creating a service account
+//
+// Example of how to run this code:
+//
+// $ terraform init
+// $ GOOGLE_CREDENTIALS=account.json GOOGLE_PROJECT=my-project terraform apply
+provider "google" {}
+
+module "lacework_svc_account" {
+  source = "../../"
+  create = false
+}

--- a/main.tf
+++ b/main.tf
@@ -11,12 +11,9 @@ locals {
   project_roles      = var.org_integration ? [] : (var.create ? local.default_project_roles : [])
   organization_roles = var.create && var.org_integration ? local.default_organization_roles : []
   project_id         = data.google_project.selected.project_id
-  service_account_name = var.create ? (
-    length(google_service_account.lacework) > 0 ? google_service_account.lacework[0].display_name : ""
-  ) : data.google_service_account.selected[0].display_name
   service_account_email = var.create ? (
     length(google_service_account.lacework) > 0 ? google_service_account.lacework[0].email : ""
-  ) : data.google_service_account.selected[0].email
+  ) : ""
 }
 
 data "google_project" "selected" {
@@ -62,10 +59,4 @@ resource "google_service_account_key" "lacework" {
     google_organization_iam_member.for_lacework_service_account,
     google_project_iam_member.for_lacework_service_account
   ]
-}
-
-data "google_service_account" "selected" {
-  count      = var.create ? 0 : 1
-  account_id = var.service_account_name
-  project    = local.project_id
 }

--- a/output.tf
+++ b/output.tf
@@ -4,7 +4,7 @@ output "created" {
 }
 
 output "name" {
-  value       = local.service_account_name
+  value       = var.service_account_name
   description = "The Service Account name"
 }
 

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -9,6 +9,7 @@ set -eou pipefail
 readonly project_name=terraform-gcp-service-account
 
 TEST_CASES=(
+  examples/prevent-service-account-creation
   examples/custom-organization-level-service-account
   examples/default-project-level-service-account
 )

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "org_integration" {
 variable "service_account_name" {
   type        = string
   default     = "lacework-svc-account"
-  description = "The Service Account name"
+  description = "The service account name"
 }
 
 variable "organization_id" {


### PR DESCRIPTION
We had a bug in our module where we were using a `google_service_account`
data-source to pull the information about an existing service account using
the service account name, but this data-source is not needed so the solution
here is to remove it.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>