### PR TITLE
feat: support service accounts for GCR integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,29 @@
 [![CircleCI status](https://circleci.com/gh/lacework/terraform-gcp-service-account.svg?style=shield)](https://circleci.com/gh/lacework/terraform-gcp-service-account)
 
 Terraform module that creates a service account to provide Lacework read-only access to Google Cloud Platform Organizations and Projects.
+
+## Simple Usage
+
+### For Compliance Integration
+
+```hcl
+provider "google" {}
+
+module "lacework_svc_account" {
+  source  = "lacework/service-account/gcp"
+  version = "~> 0.1.3"
+}
+```
+
+### For GCR Integration
+
+```hcl
+provider "google" {}
+
+module "lacework_gcr_svc_account" {
+  source         = "lacework/service-account/gcp"
+  version        = "~> 0.1.3"
+  for_gcr        = true
+  for_compliance = false
+}
+```

--- a/compliance.tf
+++ b/compliance.tf
@@ -1,0 +1,34 @@
+locals {
+  default_project_roles = [
+    "roles/viewer",
+    "roles/iam.securityReviewer"
+  ]
+  default_organization_roles = [
+    "roles/viewer",
+    "roles/iam.securityReviewer",
+    "roles/resourcemanager.organizationViewer"
+  ]
+  project_roles = var.for_compliance && var.org_integration ? [] : (
+    var.create ? local.default_project_roles : []
+  )
+  organization_roles = var.for_compliance && var.create && var.org_integration ? (
+    local.default_organization_roles
+  ) : []
+}
+
+// Roles for a PROJECT level integration
+resource "google_project_iam_member" "for_lacework_service_account" {
+  for_each = toset(local.project_roles)
+  project  = local.project_id
+  role     = each.value
+  member   = "serviceAccount:${local.service_account_email}"
+}
+
+// Roles for an ORGANIZATION level integration
+resource "google_organization_iam_member" "for_lacework_service_account" {
+  for_each = toset(local.organization_roles)
+  org_id   = var.organization_id
+  role     = each.value
+  member   = "serviceAccount:${local.service_account_email}"
+}
+

--- a/examples/custom-organization-level-service-account/README.md
+++ b/examples/custom-organization-level-service-account/README.md
@@ -12,7 +12,7 @@ Code inside a `main.tf` file:
 provider "google" {}
 
 module "lacework_svc_account" {
-  source               = "lacework/audit-log/gcp"
+  source               = "lacework/service-account/gcp"
   version              = "~> 0.1.0"
   org_integration      = true
   organization_id      = "my-organization-id"

--- a/examples/default-project-level-service-account/README.md
+++ b/examples/default-project-level-service-account/README.md
@@ -11,7 +11,7 @@ Code inside a `main.tf` file:
 provider "google" {}
 
 module "lacework_svc_account" {
-  source  = "lacework/audit-log/gcp"
+  source  = "lacework/service-account/gcp"
   version = "~> 0.1.0"
 }
 ```

--- a/examples/for-gcr-integration/README.md
+++ b/examples/for-gcr-integration/README.md
@@ -1,0 +1,26 @@
+# Create Service Account For GCR Integration
+
+This example shows how to create a service account to integrate
+Google Container Registry (GCR) with Lacework.
+
+## Example
+
+Code inside a `main.tf` file:
+
+```hcl
+provider "google" {}
+
+module "lacework_gcr_svc_account" {
+  source         = "lacework/service-account/gcp"
+  version        = "~> 0.1.3"
+  for_gcr        = true
+  for_compliance = false
+}
+```
+
+Run Terraform:
+```
+$ terraform init
+$ GOOGLE_CREDENTIALS=account.json GOOGLE_PROJECT=my-project terraform apply
+```
+

--- a/examples/for-gcr-integration/README.md
+++ b/examples/for-gcr-integration/README.md
@@ -5,7 +5,7 @@ Google Container Registry (GCR) with Lacework.
 
 ## Example
 
-Code inside a `main.tf` file:
+Copy and paste the following code into a `main.tf` file:
 
 ```hcl
 provider "google" {}
@@ -23,4 +23,3 @@ Run Terraform:
 $ terraform init
 $ GOOGLE_CREDENTIALS=account.json GOOGLE_PROJECT=my-project terraform apply
 ```
-

--- a/examples/for-gcr-integration/main.tf
+++ b/examples/for-gcr-integration/main.tf
@@ -1,0 +1,9 @@
+// $ terraform init
+// $ GOOGLE_CREDENTIALS=account.json GOOGLE_PROJECT=my-project terraform apply
+provider "google" {}
+
+module "lacework_gcr_svc_acc" {
+  source         = "../../"
+  for_gcr        = true
+  for_compliance = false
+}

--- a/gcr.tf
+++ b/gcr.tf
@@ -1,0 +1,26 @@
+locals {
+  default_gcr_roles = [
+    "roles/storage.objectViewer"
+  ]
+  required_gcr_apis = {
+    containerregistry = "containerregistry.googleapis.com"
+  }
+  gcr_roles = var.create && var.for_gcr ? local.default_gcr_roles : []
+  gcr_apis  = var.create && var.for_gcr ? local.required_gcr_apis : {}
+}
+
+resource "google_project_service" "required_apis_for_gcr_integration" {
+  for_each = local.gcr_apis
+  project  = local.project_id
+  service  = each.value
+
+  disable_on_destroy = false
+}
+
+// Role(s) for a GCR integration
+resource "google_project_iam_member" "for_gcr_integration" {
+  for_each = toset(local.gcr_roles)
+  project  = local.project_id
+  role     = each.value
+  member   = "serviceAccount:${local.service_account_email}"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,5 @@
 locals {
-  default_project_roles = [
-    "roles/viewer",
-    "roles/iam.securityReviewer"
-  ]
-  default_organization_roles = [
-    "roles/viewer",
-    "roles/iam.securityReviewer",
-    "roles/resourcemanager.organizationViewer"
-  ]
-  project_roles      = var.org_integration ? [] : (var.create ? local.default_project_roles : [])
-  organization_roles = var.create && var.org_integration ? local.default_organization_roles : []
-  project_id         = data.google_project.selected.project_id
+  project_id = data.google_project.selected.project_id
   service_account_email = var.create ? (
     length(google_service_account.lacework) > 0 ? google_service_account.lacework[0].email : ""
   ) : ""
@@ -34,22 +23,6 @@ resource "google_service_account" "lacework" {
   account_id   = var.service_account_name
   display_name = var.service_account_name
   depends_on   = [google_project_service.required_apis]
-}
-
-// Roles for a PROJECT level integration
-resource "google_project_iam_member" "for_lacework_service_account" {
-  for_each = toset(local.project_roles)
-  project  = local.project_id
-  role     = each.value
-  member   = "serviceAccount:${local.service_account_email}"
-}
-
-// Roles for an ORGANIZATION level integration
-resource "google_organization_iam_member" "for_lacework_service_account" {
-  for_each = toset(local.organization_roles)
-  org_id   = var.organization_id
-  role     = each.value
-  member   = "serviceAccount:${local.service_account_email}"
 }
 
 resource "google_service_account_key" "lacework" {

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -12,6 +12,7 @@ TEST_CASES=(
   examples/prevent-service-account-creation
   examples/custom-organization-level-service-account
   examples/default-project-level-service-account
+  examples/for-gcr-integration
 )
 
 log() {

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "for_gcr" {
 variable "for_compliance" {
   type        = bool
   default     = true
-  description = "If set to false, avoid configuring the service-account for Compliance integration"
+  description = "If set to true, configure the service-account for Compliance integration"
 }
 
 variable "org_integration" {

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,20 @@ variable "required_apis" {
   }
 }
 
+variable "for_gcr" {
+  type        = bool
+  default     = false
+  description = "If set to true, configure the service-account for GCR integration"
+}
+
+# This variable is set to true by default so that we don't break existing
+# workflows from our Cloud Account modules, gcp-config and gcp-audit-log
+variable "for_compliance" {
+  type        = bool
+  default     = true
+  description = "If set to false, avoid configuring the service-account for Compliance integration"
+}
+
 variable "org_integration" {
   type        = bool
   default     = false


### PR DESCRIPTION
As a Lacework user that uses Terraform,
I want to be able to create a service account to integrate Google Container Registry (GCR) with Lacework using Terraform,
So I don't have to worry about creating a Service Account manually.

To create a service account for GCR integration:
```hcl
provider "google" {}

module "lacework_gcr_svc_account" {
  source         = "lacework/service-account/gcp"
  version        = "~> 0.1.3"
  for_gcr        = true
  for_compliance = false
}
```

Note that the `for_compliance` variable is set to true by default so that
we don't break existing workflows from our Cloud Account modules,
gcp-config and gcp-audit-log.

**Contributes to ALLY-296**

This new feature allows users to combine this module with our resource
that configures a GCR integration, here is a quick example:
```hcl
locals {
  gcr_credentials = jsondecode(base64decode(module.lacework_gcr_svc_account.private_key))
}

provider "lacework" {}

provider "google" {}

module "lacework_gcr_svc_account" {
  source         = "lacework/service-account/gcp"
  version        = "~> 0.1.3"
  for_gcr        = true
  for_compliance = false
}

resource "lacework_integration_gcr" "example" {
  name            = "GRC Integration with Module"
  registry_domain = "gcr.io"
  credentials {
    client_id      = local.gcr_credentials.client_id
    client_email   = local.gcr_credentials.client_email
    private_key_id = local.gcr_credentials.private_key_id
    private_key    = local.gcr_credentials.private_key
  }
}
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>