### PR TITLE
fix: unique suffix added to service account name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,10 +4,7 @@ locals {
     length(google_service_account.lacework) > 0 ? google_service_account.lacework[0].email : ""
   ) : ""
   service_account_name = length(var.service_account_name) > 0 ? (
-    var.service_account_name
-    ) : (
-    "lwsvc-${random_id.uniq.hex}"
-  )
+    var.service_account_name ) : "lwsvc-${random_id.uniq.hex}"
 }
 
 resource "random_id" "uniq" {

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,15 @@ locals {
   service_account_email = var.create ? (
     length(google_service_account.lacework) > 0 ? google_service_account.lacework[0].email : ""
   ) : ""
+  service_account_name = length(var.service_account_name) > 0 ? (
+    var.service_account_name
+    ) : (
+    "lwsvc-${random_id.uniq.hex}"
+  )
+}
+
+resource "random_id" "uniq" {
+  byte_length = 4
 }
 
 data "google_project" "selected" {
@@ -20,8 +29,8 @@ resource "google_project_service" "required_apis" {
 resource "google_service_account" "lacework" {
   count        = var.create ? 1 : 0
   project      = local.project_id
-  account_id   = var.service_account_name
-  display_name = var.service_account_name
+  account_id   = local.service_account_name
+  display_name = local.service_account_name
   depends_on   = [google_project_service.required_apis]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "org_integration" {
 
 variable "service_account_name" {
   type        = string
-  default     = "lacework-svc-account"
+  default     = ""
   description = "The service account name"
 }
 


### PR DESCRIPTION
Customers are experiencing the following problem:
```
Error: Error creating service account: googleapi: Error 409: Service account lacework-svc-account already exists within project projects/abc-demo-project-123., alreadyExists
```

This PR is adding a unique suffix to the default service account name.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>