### PR TITLE
ci: switch releases to be own by Lacework releng ⚡

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "58:ab:99:3b:79:3d:71:ea:d5:38:02:e5:35:bc:2e:eb"
+            - "11:86:6e:2d:bd:e7:92:68:ef:4f:ef:27:f2:b3:4c:10"
       - run: scripts/release.sh trigger
   release:
     executor: alpine

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,8 +10,8 @@ set -eou pipefail
 
 readonly org_name=lacework
 readonly project_name=terraform-gcp-service-account
-readonly git_user="Salim Afiune Maya"
-readonly git_email="afiune@lacework.net"
+readonly git_user="Lacework Inc."
+readonly git_email="ops+releng@lacework.net"
 VERSION=$(cat VERSION)
 
 usage() {


### PR DESCRIPTION
As a Lacework Engineer, 
I would like to use an in-house Github account to set up all releases and pipelines
So I don't have to use my personal Github account.

## Description
We are starting to use the company's Github account https://github.com/lacework-releng to do
our automated releases.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>