### PR TITLE
ci: ignore .terraform.lock.hcl files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Local .terraform directories
 **/.terraform/*
 
+# generated via "make ci"
+examples/**/.terraform.lock.hcl
+
 # .tfstate files
 *.tfstate
 *.tfstate.*


### PR DESCRIPTION

***Issue***: N/A

***Description:***
Our release pipeline failed with:
```
scripts/release.sh prepare                                                                                                                                                                                                                         
--> terraform-gcp-service-account: preparing new release                                                                                                                                                                                           
xxx terraform-gcp-service-account: You have unsaved changes in the main branch. Are you resuming a release?                                                                                                                                        
xxx terraform-gcp-service-account: To resume a release you have to start over, to remove all unsaved changes run the command:                                                                                                                      
xxx terraform-gcp-service-account:   git reset --hard origin/main                                                                                                                                                                                  
make: *** [GNUmakefile:17: release] Error 127                                                                                                                                                                                                      
```
