### PR TITLE
feat: timebound key rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ other Lacework GCP modules.
 |project_id|A project ID different from the default defined inside the provider|string|""|false|
 |service_account_name|The Service Account name|string|""|false|
 |create|Set to false to prevent the module from creating any resources|bool|false|false|
+|key_rotation_duration_days|Duration to use single service account key for|number|0|false|
 
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,8 @@ data "google_project" "selected" {
 
 resource "time_rotating" "lacework_key_rotation" {
   count         = local.use_keepers ? 1 : 0
-  rotation_days = var.key_rotation_duration_days
+  rotation_minutes = var.key_rotation_duration_days
+  # can test using minutes
 }
 
 resource "google_service_account" "lacework" {
@@ -31,5 +32,5 @@ resource "google_service_account" "lacework" {
 resource "google_service_account_key" "lacework" {
   count              = var.create ? 1 : 0
   service_account_id = google_service_account.lacework[count.index].name
-  keepers            =  local.use_keepers ? time_rotating.lacework_key_rotation.rotation_rfc3339 : {}
+  keepers            =  local.use_keepers ? { rotation_time = time_rotating.lacework_key_rotation[count.index].rotation_rfc3339} : null
 }

--- a/main.tf
+++ b/main.tf
@@ -17,9 +17,8 @@ data "google_project" "selected" {
 }
 
 resource "time_rotating" "lacework_key_rotation" {
-  count         = local.use_keepers ? 1 : 0
-  rotation_minutes = var.key_rotation_duration_days
-  # can test using minutes
+  count                  = local.use_keepers ? 1 : 0
+  rotation_rotation_days = var.key_rotation_duration_days
 }
 
 resource "google_service_account" "lacework" {

--- a/variables.tf
+++ b/variables.tf
@@ -19,3 +19,9 @@ variable "create" {
   default     = true
   description = "Set to false to prevent the module from creating any resources"
 }
+
+variable "key_rotation_duration_days" {
+  type        = number
+  default     = 0
+  description = "Duration after which to rotate service account key"
+}


### PR DESCRIPTION
## Summary

Customers have requested being able to automatically rotate service account keys after a specified time duration has passed. 

## How did you test this change?

Frankly, testing has been executed by switching the `duration_days` input to be `duration_minutes` to trigger a rotation interval faster. 

