### PR TITLE
feat: deprecate support for Terraform 0.12 and 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,46 @@
 [![GitHub release](https://img.shields.io/github/release/lacework/terraform-gcp-service-account.svg)](https://github.com/lacework/terraform-gcp-service-account/releases/)
 [![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/lacework/terraform-modules%2Ftest-compatibility?type=cf-1&key=eyJhbGciOiJIUzI1NiJ9.NWVmNTAxOGU4Y2FjOGQzYTkxYjg3ZDEx.RJ3DEzWmBXrJX7m38iExJ_ntGv4_Ip8VTa-an8gBwBo)]( https://g.codefresh.io/pipelines/edit/new/builds?id=607e25e6728f5a6fba30431b&pipeline=test-compatibility&projects=terraform-modules&projectId=607db54b728f5a5f8930405d)
 
-Terraform module that creates service account with no roles 
-on a Google Cloud Platform Project to be used in conjunction with 
+Terraform module that creates service account with no roles
+on a Google Cloud Platform Project to be used in conjunction with
 other Lacework GCP modules.
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.0.0, < 5.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.0.0, < 5.0.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_service_account.lacework](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_key.lacework](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key) | resource |
+| [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [google_project.selected](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|----------|
-|project_id|A project ID different from the default defined inside the provider|string|""|false|
-|service_account_name|The Service Account name|string|""|false|
-|create|Set to false to prevent the module from creating any resources|bool|false|false|
-
+|------|-------------|------|---------|:--------:|
+| <a name="input_create"></a> [create](#input\_create) | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | A project ID different from the default defined inside the provider | `string` | `""` | no |
+| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The service account name | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-|created|Was the Service Account created|
-|name|The Service Account name|
-|private_key|The private key in JSON format, base64 encoded|
-|project_id|The Project ID|
+| <a name="output_created"></a> [created](#output\_created) | Was the Service Account created |
+| <a name="output_name"></a> [name](#output\_name) | The Service Account name |
+| <a name="output_private_key"></a> [private\_key](#output\_private\_key) | The private key in JSON format, base64 encoded |
+| <a name="output_project_id"></a> [project\_id](#output\_project\_id) | The Project ID |

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 0.14"
 
   required_providers {
     google = ">= 3.0.0, < 5.0.0"


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Deprecate support for Terraform 0.12 and 0.13

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Add Terraform 1.1 to terraform modules compatibility tests

## Issue

https://lacework.atlassian.net/browse/ALLY-954

