### PR TITLE
deps: upgrade google provider min version to 4.4.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.14"
 
   required_providers {
-    google = ">= 3.0.0, < 5.0.0"
+    google = ">= 4.4.0, < 5.0.0"
   }
 }


### PR DESCRIPTION

## Summary

We need to synchronize the version pin from upstream dependencies since they are causing
confusion and we don't really support any version of the google provider older than `4.4.0`

## How did you test this change?

No need since this is just upgrading the min version, not the major.

## Issue

Fixes https://github.com/lacework/terraform-gcp-audit-log/issues/67

