### PR TITLE
fix: fix project id validation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "project_id" {
   default     = ""
   description = "A project ID different from the default defined inside the provider"
   validation {
-    condition     = can(regex("(^[a-z][a-z0-9_-]{6,30}[^-]$|^$)", var.project_id))
+    condition     = can(regex("(^[a-z][a-z0-9_-]{4,28}[^-]$|^$)", var.project_id))
     error_message = "The project_id variable must be a valid GCP project ID. It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited.. Example: tokyo-rain-123."
   }
 }


### PR DESCRIPTION
Make the project id validation regex match the error message

## Summary
The regex validation that exists today is incorrect. Instead of checking that the total number of characters is between 6-30, it actually ensures it's between 8-32. That is because:
* ^ - starts with
* [a-z] - a single char between a to z
* [a-z0-9_-]{6,30} - between 6 to 30 chars of alphanumeric chars plus hyphen and underscore.
* [^-] - not a hyphen
* $ - end
Once the count includes the single char in the beginning and the non hyphen in the end it totals to 8 to 32 characters.

## How did you test this change?
used an online regex tester to verify this works with my GCP project that is currently failing
