### PR TITLE
fix: empty project_id in google_project data source

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,19 +1,17 @@
 locals {
-  project_id = data.google_project.selected.project_id
+  project_id = length(var.project_id) > 0 ? var.project_id : data.google_project.selected.project_id
   service_account_email = var.create ? (
     length(google_service_account.lacework) > 0 ? google_service_account.lacework[0].email : ""
   ) : ""
   service_account_name = length(var.service_account_name) > 0 ? (
-    var.service_account_name ) : "lwsvc-${random_id.uniq.hex}"
+  var.service_account_name) : "lwsvc-${random_id.uniq.hex}"
 }
 
 resource "random_id" "uniq" {
   byte_length = 4
 }
 
-data "google_project" "selected" {
-  project_id = var.project_id
-}
+data "google_project" "selected" {}
 
 resource "google_service_account" "lacework" {
   count        = var.create ? 1 : 0


### PR DESCRIPTION

## Summary
A validation change https://github.com/hashicorp/terraform-provider-google/pull/12846 was introduced in version `4.42.0` of the google provider. This validation makes all our GCP modules to fail with:
```
│ Error: "" project_id must be 6 to 30 with lowercase letters, digits, hyphens and start with a letter. Trailing hyphens are prohibited.
│
│   with module.gcp_service_account.data.google_project.selected,
│   on .terraform/modules/gcp_service_account/main.tf line 96, in data "google_project" "selected":
│   96:   project_id = var.project_id
```

To solve this issue we are avoiding using the `google_project` data source when we know the `project_id` that was provided by the user.

If the user does not provide a `project_id`, then we use the data source to discover the project from the google provider.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

## How did you test this change?

Test should pass, plus we will test this in our private Terraform project https://github.com/lacework/terraform-customerdemo

## Issue

- https://lacework.atlassian.net/browse/RAIN-39458
- https://lacework.atlassian.net/browse/RAIN-37109

