### PR TITLE
fix: avoid asking for project_id when is not needed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  project_id = length(var.project_id) > 0 ? var.project_id : data.google_project.selected.project_id
+  project_id = length(var.project_id) > 0 ? var.project_id : data.google_project.selected[0].project_id
   service_account_email = var.create ? (
     length(google_service_account.lacework) > 0 ? google_service_account.lacework[0].email : ""
   ) : ""
@@ -11,7 +11,9 @@ resource "random_id" "uniq" {
   byte_length = 4
 }
 
-data "google_project" "selected" {}
+data "google_project" "selected" {
+  count = length(var.project_id) > 0 ? 0 : 1
+}
 
 resource "google_service_account" "lacework" {
   count        = var.create ? 1 : 0


### PR DESCRIPTION
## Summary

Avoid error message:
```
Error: no project value set. project_id must be set at the resource level, or a default project value must be specified on the provider
```


## Issue
https://lacework.atlassian.net/browse/LINK-1338
